### PR TITLE
Change webkit to Chromium

### DIFF
--- a/src/pages/articles/my-macos-setup.md
+++ b/src/pages/articles/my-macos-setup.md
@@ -46,7 +46,7 @@ As a contract front end developer I find myself setting up MacOS laptops quite o
 		* It will fail wanting you to accept license terms
 		* `VBoxManage extpack install /Users/csilk/.ievms/Oracle_VM_VirtualBox_Extension_Pack-` (tab to auto complete then enter) then accept licence terms
 		* Run 1 again
-* [Edge Preview (webkit)](https://apps.apple.com/us/app/microsoft-edge/id1288723196)
+* [Edge Preview (Chromium)](https://apps.apple.com/us/app/microsoft-edge/id1288723196)
 
 ## iOS Simulator (test)
 


### PR DESCRIPTION
Hi, thanks for this repo!

The new Edge browser is not based on Webkit, it's based on Chromium (if you want to only mention the rendering engine it is called Blink).