### PR TITLE
docs: discord voice transcription with OpenClaw + Deepgram

### DIFF
--- a/src/articles/discord-voice-transcription-openclaw-deepgram.md
+++ b/src/articles/discord-voice-transcription-openclaw-deepgram.md
@@ -51,12 +51,12 @@ A few things I find myself doing:
 - **Quick tasks** — "add a task to check the CI pipeline after lunch" without opening anything
 - **Meeting notes** — voice-summarising what just happened in a call while it's still fresh
 
-It's the kind of thing that sounds gimmicky until you use it for a week and realise you're capturing twice as much stuff because the friction dropped to almost zero.
+It sounds gimmicky until you've used it for a week and realise you're capturing twice as much because the friction is almost zero.
 
 ## Cost
 
-Deepgram gives you $200 in free credit on signup which goes a long way for short voice messages. After that, Nova-2 runs at $0.0043/minute — a 30-second voice message costs a fraction of a cent. I've been using it daily and haven't made a dent in the free tier.
+Deepgram gives you $200 in free credit on signup. Nova-2 runs at $0.0043/minute — a 30-second voice message is a fraction of a cent. I've been using it daily and haven't dented the free tier.
 
 ## The takeaway
 
-The interesting part wasn't the technical setup — that was trivial. It was the workflow shift. Typing a message to an AI assistant is fine when you're at a desk. Being able to just *talk* while doing other things makes it actually useful as a capture tool rather than something you have to sit down and use.
+The setup was trivial. The shift was in how I use the assistant — talking while doing other things instead of stopping to type. Friction went down, capture went up.

--- a/src/articles/discord-voice-transcription-openclaw-deepgram.md
+++ b/src/articles/discord-voice-transcription-openclaw-deepgram.md
@@ -1,25 +1,20 @@
 ---
-title: Discord voice message transcription with OpenClaw and Deepgram
-description: How to automatically transcribe Discord voice messages using OpenClaw and Deepgram's Nova speech-to-text API
+title: Talking to my AI assistant via Discord voice messages
+description: Using Discord voice messages with OpenClaw and Deepgram to capture thoughts, extract tasks and take notes by just talking
 permalink: articles/discord-voice-transcription-openclaw-deepgram.html
 tags: article
-keywords: discord, voice, transcription, deepgram, openclaw, speech-to-text, nova, audio, bot
+keywords: discord, voice, transcription, deepgram, openclaw, speech-to-text, ai, assistant, tasks, notes
 layout: article
 date: 2025-02-05
 ---
 
-I wanted my Discord bot to understand voice messages — not just text. Discord added voice messages a while back and people actually use them, but most bots just ignore the audio entirely.
+I run an AI assistant ([OpenClaw](https://github.com/openclaw/openclaw)) that lives in my Discord server. It manages my notes, tasks, calendar — basically a second brain I can message. The problem is I don't always want to type. Sometimes I'm walking the dog or cooking and I just want to say "remind me to check the deployment tomorrow" and have it handled.
 
-[OpenClaw](https://github.com/openclaw/openclaw) has built-in audio transcription support via [Deepgram](https://deepgram.com), so the setup is surprisingly minimal.
+Discord has voice messages built in. Long press the mic, talk, send. So the question was: can I pipe that audio through to my assistant and have it actually understand what I said?
 
-## Prerequisites
+## The setup
 
-- A running OpenClaw instance with Discord connected
-- A [Deepgram API key](https://console.deepgram.com/) (free tier works fine)
-
-## Setup
-
-Add your Deepgram API key to the OpenClaw config:
+Turns out OpenClaw already supports audio transcription via [Deepgram](https://deepgram.com). The entire setup was two config changes — add an API key and enable the audio provider:
 
 ```json
 {
@@ -27,43 +22,14 @@ Add your Deepgram API key to the OpenClaw config:
     "vars": {
       "DEEPGRAM_API_KEY": "your_key_here"
     }
-  }
-}
-```
-
-Then enable audio transcription with the Deepgram provider:
-
-```json
-{
+  },
   "tools": {
     "media": {
       "audio": {
         "enabled": true,
-        "models": [
-          { "provider": "deepgram", "model": "nova-2" }
-        ]
-      }
-    }
-  }
-}
-```
-
-Restart the gateway and you're done.
-
-## Optional: smart formatting
-
-Deepgram has some nice formatting options that clean up the transcript output — punctuation, capitalisation, formatting numbers properly:
-
-```json
-{
-  "tools": {
-    "media": {
-      "audio": {
+        "models": [{ "provider": "deepgram", "model": "nova-2" }],
         "providerOptions": {
-          "deepgram": {
-            "punctuate": true,
-            "smart_format": true
-          }
+          "deepgram": { "punctuate": true, "smart_format": true }
         }
       }
     }
@@ -71,19 +37,26 @@ Deepgram has some nice formatting options that clean up the transcript output �
 }
 ```
 
-## How it works
+Restart the gateway, done. No webhook plumbing, no separate transcription service, no glue code. When a voice message lands in Discord, OpenClaw picks up the audio attachment, sends it to Deepgram, gets the transcript back and treats it like any other text message.
 
-When someone sends a voice message in Discord, OpenClaw:
+I was expecting at least an afternoon of debugging. It took about ten minutes.
 
-1. Detects the audio attachment
-2. Sends it to Deepgram's pre-recorded transcription endpoint
-3. Injects the transcript into the conversation as text
+## What I actually use it for
 
-The bot then responds to the transcribed text like any other message. No streaming — it transcribes the whole clip first, then replies.
+The real value isn't the transcription — it's what happens after. My assistant already knows how to create tasks, update notes, and add calendar events. Voice messages just became another input method.
 
-## Notes
+A few things I find myself doing:
 
-- Deepgram's free tier gives you $200 in credit which is plenty for voice messages
-- `nova-2` is the model I'm using — solid accuracy, fast, cheap
-- Max file size is configurable via `tools.media.audio.maxBytes` (default 20MB)
-- Works with any audio format Discord sends (usually ogg/opus)
+- **Brain dumps** — rambling about a project while walking, then asking the assistant to extract the action items
+- **Quick tasks** — "add a task to check the CI pipeline after lunch" without opening anything
+- **Meeting notes** — voice-summarising what just happened in a call while it's still fresh
+
+It's the kind of thing that sounds gimmicky until you use it for a week and realise you're capturing twice as much stuff because the friction dropped to almost zero.
+
+## Cost
+
+Deepgram gives you $200 in free credit on signup which goes a long way for short voice messages. After that, Nova-2 runs at $0.0043/minute — a 30-second voice message costs a fraction of a cent. I've been using it daily and haven't made a dent in the free tier.
+
+## The takeaway
+
+The interesting part wasn't the technical setup — that was trivial. It was the workflow shift. Typing a message to an AI assistant is fine when you're at a desk. Being able to just *talk* while doing other things makes it actually useful as a capture tool rather than something you have to sit down and use.

--- a/src/articles/discord-voice-transcription-openclaw-deepgram.md
+++ b/src/articles/discord-voice-transcription-openclaw-deepgram.md
@@ -1,0 +1,89 @@
+---
+title: Discord voice message transcription with OpenClaw and Deepgram
+description: How to automatically transcribe Discord voice messages using OpenClaw and Deepgram's Nova speech-to-text API
+permalink: articles/discord-voice-transcription-openclaw-deepgram.html
+tags: article
+keywords: discord, voice, transcription, deepgram, openclaw, speech-to-text, nova, audio, bot
+layout: article
+date: 2025-02-05
+---
+
+I wanted my Discord bot to understand voice messages — not just text. Discord added voice messages a while back and people actually use them, but most bots just ignore the audio entirely.
+
+[OpenClaw](https://github.com/openclaw/openclaw) has built-in audio transcription support via [Deepgram](https://deepgram.com), so the setup is surprisingly minimal.
+
+## Prerequisites
+
+- A running OpenClaw instance with Discord connected
+- A [Deepgram API key](https://console.deepgram.com/) (free tier works fine)
+
+## Setup
+
+Add your Deepgram API key to the OpenClaw config:
+
+```json
+{
+  "env": {
+    "vars": {
+      "DEEPGRAM_API_KEY": "your_key_here"
+    }
+  }
+}
+```
+
+Then enable audio transcription with the Deepgram provider:
+
+```json
+{
+  "tools": {
+    "media": {
+      "audio": {
+        "enabled": true,
+        "models": [
+          { "provider": "deepgram", "model": "nova-2" }
+        ]
+      }
+    }
+  }
+}
+```
+
+Restart the gateway and you're done.
+
+## Optional: smart formatting
+
+Deepgram has some nice formatting options that clean up the transcript output — punctuation, capitalisation, formatting numbers properly:
+
+```json
+{
+  "tools": {
+    "media": {
+      "audio": {
+        "providerOptions": {
+          "deepgram": {
+            "punctuate": true,
+            "smart_format": true
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+## How it works
+
+When someone sends a voice message in Discord, OpenClaw:
+
+1. Detects the audio attachment
+2. Sends it to Deepgram's pre-recorded transcription endpoint
+3. Injects the transcript into the conversation as text
+
+The bot then responds to the transcribed text like any other message. No streaming — it transcribes the whole clip first, then replies.
+
+## Notes
+
+- Deepgram's free tier gives you $200 in credit which is plenty for voice messages
+- `nova-2` is the model I'm using — solid accuracy, fast, cheap
+- Max file size is configurable via `tools.media.audio.maxBytes` (default 20MB)
+- Works with any audio format Discord sends (usually ogg/opus)


### PR DESCRIPTION
First article for the pipeline 🐾

Covers setting up Discord voice message transcription using OpenClaw's built-in Deepgram integration. Kept it short and practical — matches the existing article format.